### PR TITLE
Change default mode for .tcl to Tcl rather than HTML (Tcl).

### DIFF
--- a/grammars/html (tcl).cson
+++ b/grammars/html (tcl).cson
@@ -1,5 +1,5 @@
 'fileTypes': [
-  'tcl'
+  'html.tcl'
   'adp'
   'inc'
 ]


### PR DESCRIPTION
Seems like a better default.  Not sure of the 'right' way to do priority between modes for identical file types; e.g. .rb is Ruby by default, not Ruby on Rails.
