### PR TITLE
Set default comment symbol to #

### DIFF
--- a/settings/language-tcl.cson
+++ b/settings/language-tcl.cson
@@ -1,6 +1,7 @@
 '.source.tcl':
   'editor':
     'increaseIndentPattern': '\\{[^"\'}]*$'
+    'commentStart': '# '
 '.source.antlr':
   'editor':
     'foldEndPattern': '^\\s*\\}'


### PR DESCRIPTION
Hi,

Tcl uses `#` for comments, so this pull request sets the default comment symbol to be `#`, which in turn resolves issue #13.

Caleb
