### PR TITLE
comment action by {\\}

### DIFF
--- a/grammars/tcl.cson
+++ b/grammars/tcl.cson
@@ -237,3 +237,6 @@
     'match': '(\\$)((?:[a-zA-Z0-9_]|::)+(\\([^\\)]+\\))?|\\{[^\\}]*\\})'
     'name': 'variable.other.tcl'
 'scopeName': 'source.tcl'
+
+comments:
+  start: '# '

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-tcl",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "description": "Syntax highlighting for Tcl",
   "repository": "https://github.com/dacieri/language-tcl",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-tcl",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "Syntax highlighting for Tcl",
   "repository": "https://github.com/dacieri/language-tcl",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-tcl",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "description": "Syntax highlighting for Tcl",
   "repository": "https://github.com/dacieri/language-tcl",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "language-tcl",
+  "name": "language-tcl-new",
   "version": "0.3.6",
   "private": true,
   "description": "Syntax highlighting for Tcl",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-tcl",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "description": "Syntax highlighting for Tcl",
   "repository": "https://github.com/dacieri/language-tcl",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-tcl-new",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "private": true,
   "description": "Syntax highlighting for Tcl",
   "repository": "https://github.com/dacieri/language-tcl",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "private": true,
   "description": "Syntax highlighting for Tcl",
-  "repository": "https://github.com/zpconn/language-tcl",
+  "repository": "https://github.com/dacieri/language-tcl",
   "license": "MIT",
   "engines": {
     "atom": ">0.50.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-tcl",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Syntax highlighting for Tcl",
   "repository": "https://github.com/dacieri/language-tcl",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-tcl",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "private": true,
   "description": "Syntax highlighting for Tcl",
   "repository": "https://github.com/dacieri/language-tcl",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-tcl",
-  "version": "0.3.4",
+  "version": "0.3.6",
   "private": true,
   "description": "Syntax highlighting for Tcl",
   "repository": "https://github.com/dacieri/language-tcl",


### PR DESCRIPTION
double Backslash issue:
These code lines will cause that after {\\\\} = {two backslashes not one} lines are comments as green:

set command [regsub -all {\\\\} $stringle  {\\\\\\\\} ]
  
Best regards
Jochen
